### PR TITLE
Updated examples to link

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The Structure Arduino SDK depends on [ArduinoJson](https://github.com/bblanchon/
 
 ## Example
 
-Below is a basic example of using the Structure Arduino SDK. For specific examples for various boards, please refer to the `examples` folder.
+Below is a basic example of using the Structure Arduino SDK. For specific examples for various boards, please refer to the [`examples`](https://github.com/GetStructure/structure-sdk-arduino/tree/master/examples) folder.
 
 ```arduino
 #include <WiFi101.h>


### PR DESCRIPTION
Linked the word `examples` to the examples folder on the master branch. Made this a pull request because we may not want to always link to master branch but figure it's probably fine.
